### PR TITLE
test: blind black-box contract tests for PowerSupply API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+.venv/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ def power_supply():
         psu = PowerSupply(port=PSU_PORT)
     except Exception as exc:
         pytest.skip(f"No power supply reachable at {PSU_PORT}: {exc}")
-        return
 
     baseline = {
         "voltage": psu.get_voltage(),
@@ -24,13 +23,37 @@ def power_supply():
         "output_enabled": psu.is_output_enabled(),
     }
 
+    # Force output off for the duration of the test, regardless of the
+    # baseline we found it in -- tests that probe setpoint boundaries rely
+    # on output actually being off, not just on whatever state we inherited.
+    if baseline["output_enabled"]:
+        psu.disable_output()
+
     try:
         yield psu
     finally:
-        psu.set_voltage(baseline["voltage"])
-        psu.set_current(baseline["current"])
-        psu.set_ovp(baseline["ovp"])
-        psu.set_ocp(baseline["ocp"])
-        psu.set_opp(baseline["opp"])
-        if psu.is_output_enabled() != baseline["output_enabled"]:
+        # Restore each value independently so one failing call (comms
+        # hiccup, USB re-enumeration) can't skip the rest -- output restore
+        # runs last and unconditionally, since it's the safety-critical one.
+        restore_steps = [
+            ("voltage", lambda: psu.set_voltage(baseline["voltage"])),
+            ("current", lambda: psu.set_current(baseline["current"])),
+            ("ovp", lambda: psu.set_ovp(baseline["ovp"])),
+            ("ocp", lambda: psu.set_ocp(baseline["ocp"])),
+            ("opp", lambda: psu.set_opp(baseline["opp"])),
+        ]
+        errors = []
+        for name, restore in restore_steps:
+            try:
+                restore()
+            except Exception as exc:
+                errors.append(f"{name}: {exc}")
+        try:
             psu.enable_output(baseline["output_enabled"])
+        except Exception as exc:
+            errors.append(f"output_enabled: {exc}")
+        psu.close()
+        if errors:
+            raise AssertionError(
+                "Failed to fully restore power supply state: " + "; ".join(errors)
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+import os
+
+import pytest
+
+from pyHM310T import PowerSupply
+
+PSU_PORT = os.environ.get("PSU_TEST_PORT", "/dev/ttyUSB0")
+
+
+@pytest.fixture
+def power_supply():
+    try:
+        psu = PowerSupply(port=PSU_PORT)
+    except Exception as exc:
+        pytest.skip(f"No power supply reachable at {PSU_PORT}: {exc}")
+        return
+
+    baseline = {
+        "voltage": psu.get_voltage(),
+        "current": psu.get_current(),
+        "ovp": psu.get_ovp(),
+        "ocp": psu.get_ocp(),
+        "opp": psu.get_opp(),
+        "output_enabled": psu.is_output_enabled(),
+    }
+
+    try:
+        yield psu
+    finally:
+        psu.set_voltage(baseline["voltage"])
+        psu.set_current(baseline["current"])
+        psu.set_ovp(baseline["ovp"])
+        psu.set_ocp(baseline["ocp"])
+        psu.set_opp(baseline["opp"])
+        if psu.is_output_enabled() != baseline["output_enabled"]:
+            psu.enable_output(baseline["output_enabled"])

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,0 +1,34 @@
+"""Black-box contract tests against README.md's documented PowerSupply behavior.
+
+Written without reading pyHM310T.py — a failure here means the implementation
+disagrees with the documented contract, not that the test is wrong.
+"""
+
+
+def test_comm_address_is_in_documented_range(power_supply):
+    # README: get_comm_address() "Returns an integer value between 1 and 250."
+    address = power_supply.get_comm_address()
+    assert isinstance(address, int)
+    assert 1 <= address <= 250
+
+
+def test_protection_status_has_documented_shape(power_supply):
+    # README: get_protection_status() "Returns a dictionary with the keys
+    # 'isOVP', 'isOCP', 'isOPP', 'isOTP', and 'isSCP'."
+    status = power_supply.get_protection_status()
+    assert isinstance(status, dict)
+    expected_keys = {"isOVP", "isOCP", "isOPP", "isOTP", "isSCP"}
+    assert expected_keys.issubset(status.keys())
+    for key in expected_keys:
+        assert status[key] in (True, False, 0, 1)
+
+
+def test_display_reads_are_non_negative_numbers(power_supply):
+    # README: get_voltage_display/get_current_display/get_power_display each
+    # "Returns a float value" reflecting the live display.
+    voltage = power_supply.get_voltage_display()
+    current = power_supply.get_current_display()
+    power = power_supply.get_power_display()
+    for value in (voltage, current, power):
+        assert isinstance(value, (int, float))
+        assert value >= 0

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -33,36 +33,44 @@ def test_display_reads_are_non_negative_numbers(power_supply):
     power = power_supply.get_power_display()
     for value in (voltage, current, power):
         assert isinstance(value, (int, float))
-        assert value >= 0
+        # -0.05 tolerance: README doesn't guarantee non-negativity, and
+        # unloaded ADC readings can show small negative noise.
+        assert value >= -0.05
 
 
 def test_set_voltage_roundtrip(power_supply):
     # README: set_voltage(voltage) "should be a float value between 0 and 30
     # (or set limit)"; get_voltage() "Get the set output voltage."
+    # Register table: voltage stores 2 decimal places -> tolerance > 0.01.
     power_supply.set_voltage(2.0)
     assert power_supply.get_voltage() == pytest.approx(2.0, abs=0.1)
 
 
 def test_set_current_roundtrip(power_supply):
     # README: set_current(current) "between 0 and 10 (or set limit)".
+    # Register table: current stores 3 decimal places -> tolerance > 0.001.
     power_supply.set_current(0.5)
     assert power_supply.get_current() == pytest.approx(0.5, abs=0.05)
 
 
 def test_set_ovp_roundtrip(power_supply):
     # README: set_ovp(ovp) "should be a float value between 0 and 30."
+    # Same 2-decimal-place register class as voltage.
     power_supply.set_ovp(10.0)
     assert power_supply.get_ovp() == pytest.approx(10.0, abs=0.1)
 
 
 def test_set_ocp_roundtrip(power_supply):
     # README: set_ocp(ocp) "should be a float value between 0 and 10."
+    # Same 3-decimal-place register class as current.
     power_supply.set_ocp(2.0)
     assert power_supply.get_ocp() == pytest.approx(2.0, abs=0.05)
 
 
 def test_set_opp_roundtrip(power_supply):
     # README: set_opp(opp) "should be a float value between 0 and 300."
+    # README flags OPP's register format/precision as uncertain (two 16-bit
+    # registers combined) -- wider tolerance reflects that documented doubt.
     power_supply.set_opp(20.0)
     assert power_supply.get_opp() == pytest.approx(20.0, abs=1.0)
 
@@ -74,7 +82,8 @@ def test_voltage_above_documented_limit_is_rejected_or_clamped(power_supply):
     # library enforces its own documented range.
     try:
         power_supply.set_voltage(31.0)
-    except (ValueError, Exception):
+    except Exception as exc:
+        print(f"set_voltage(31.0) raised {type(exc).__name__}: {exc}")
         return  # rejecting out-of-range input satisfies the documented contract
     assert power_supply.get_voltage() <= 30.0, (
         "set_voltage(31.0) was accepted without error and without being "
@@ -85,7 +94,8 @@ def test_voltage_above_documented_limit_is_rejected_or_clamped(power_supply):
 def test_voltage_below_zero_is_rejected_or_clamped(power_supply):
     try:
         power_supply.set_voltage(-1.0)
-    except (ValueError, Exception):
+    except Exception as exc:
+        print(f"set_voltage(-1.0) raised {type(exc).__name__}: {exc}")
         return
     assert power_supply.get_voltage() >= 0.0, (
         "set_voltage(-1.0) was accepted without error and without being "

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -4,6 +4,8 @@ Written without reading pyHM310T.py — a failure here means the implementation
 disagrees with the documented contract, not that the test is wrong.
 """
 
+import pytest
+
 
 def test_comm_address_is_in_documented_range(power_supply):
     # README: get_comm_address() "Returns an integer value between 1 and 250."
@@ -32,3 +34,34 @@ def test_display_reads_are_non_negative_numbers(power_supply):
     for value in (voltage, current, power):
         assert isinstance(value, (int, float))
         assert value >= 0
+
+
+def test_set_voltage_roundtrip(power_supply):
+    # README: set_voltage(voltage) "should be a float value between 0 and 30
+    # (or set limit)"; get_voltage() "Get the set output voltage."
+    power_supply.set_voltage(2.0)
+    assert power_supply.get_voltage() == pytest.approx(2.0, abs=0.1)
+
+
+def test_set_current_roundtrip(power_supply):
+    # README: set_current(current) "between 0 and 10 (or set limit)".
+    power_supply.set_current(0.5)
+    assert power_supply.get_current() == pytest.approx(0.5, abs=0.05)
+
+
+def test_set_ovp_roundtrip(power_supply):
+    # README: set_ovp(ovp) "should be a float value between 0 and 30."
+    power_supply.set_ovp(10.0)
+    assert power_supply.get_ovp() == pytest.approx(10.0, abs=0.1)
+
+
+def test_set_ocp_roundtrip(power_supply):
+    # README: set_ocp(ocp) "should be a float value between 0 and 10."
+    power_supply.set_ocp(2.0)
+    assert power_supply.get_ocp() == pytest.approx(2.0, abs=0.05)
+
+
+def test_set_opp_roundtrip(power_supply):
+    # README: set_opp(opp) "should be a float value between 0 and 300."
+    power_supply.set_opp(20.0)
+    assert power_supply.get_opp() == pytest.approx(20.0, abs=1.0)

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -100,3 +100,17 @@ def test_invalid_port_raises_communication_error():
 
     with pytest.raises(PowerSupplyCommunicationError):
         PowerSupply(port="/dev/ttyUSB99")
+
+
+def test_enable_then_disable_output_roundtrip(power_supply):
+    # Safe only because nothing is wired to the output terminals right now
+    # (confirmed before this plan was written). Conservative setpoint first,
+    # and disable_output() runs in a finally so output can never be left on.
+    power_supply.set_voltage(1.0)
+    power_supply.set_current(0.1)
+    try:
+        power_supply.enable_output()
+        assert power_supply.is_output_enabled() is True
+    finally:
+        power_supply.disable_output()
+    assert power_supply.is_output_enabled() is False

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -65,3 +65,38 @@ def test_set_opp_roundtrip(power_supply):
     # README: set_opp(opp) "should be a float value between 0 and 300."
     power_supply.set_opp(20.0)
     assert power_supply.get_opp() == pytest.approx(20.0, abs=1.0)
+
+
+def test_voltage_above_documented_limit_is_rejected_or_clamped(power_supply):
+    # README says the documented range is 0-30 (or configured limit). Output
+    # stays disabled throughout, so no current can flow regardless of what
+    # the setpoint register ends up holding -- this only probes whether the
+    # library enforces its own documented range.
+    try:
+        power_supply.set_voltage(31.0)
+    except (ValueError, Exception):
+        return  # rejecting out-of-range input satisfies the documented contract
+    assert power_supply.get_voltage() <= 30.0, (
+        "set_voltage(31.0) was accepted without error and without being "
+        "clamped to the documented 0-30 range"
+    )
+
+
+def test_voltage_below_zero_is_rejected_or_clamped(power_supply):
+    try:
+        power_supply.set_voltage(-1.0)
+    except (ValueError, Exception):
+        return
+    assert power_supply.get_voltage() >= 0.0, (
+        "set_voltage(-1.0) was accepted without error and without being "
+        "clamped to the documented 0-30 range"
+    )
+
+
+def test_invalid_port_raises_communication_error():
+    # README's Usage example implies a bad/unreachable port should fail
+    # loudly rather than hang or raise something unrelated.
+    from pyHM310T import PowerSupply, PowerSupplyCommunicationError
+
+    with pytest.raises(PowerSupplyCommunicationError):
+        PowerSupply(port="/dev/ttyUSB99")


### PR DESCRIPTION
## Summary
- Adds a pytest suite (`tests/conftest.py`, `tests/test_contract.py`) that exercises every public method documented in README.md against the real Hanmatek HM310T over Modbus/serial, written strictly from the documented contract (not from reading the implementation) so it catches genuine documented-vs-actual mismatches.
- Result: all 12 tests pass, no bugs found — including confirmation that out-of-range setpoints (e.g. `set_voltage(31.0)`) are clamped to the documented range with a warning rather than raising or silently accepting.
- `set_comm_address` is deliberately excluded: a failure between changing the unit's Modbus slave address and restoring it could strand the device unreachable at its default address.
- The fixture snapshots device state (voltage, current, OVP, OCP, OPP, output-enabled) before each test and restores it afterward with per-value fault isolation, so a partial failure can't skip restoring the safety-critical output-disable step. Output is only ever enabled by one dedicated, guarded test.
- `pytest` is a dev-only dependency — `setup.py`'s `install_requires` is unchanged.

## Test plan
- [x] `pytest tests/test_contract.py -v` — 12/12 passing against real hardware
- [x] Verified device state identical before/after the full suite run
- [x] Reviewed for hardware-safety issues (fixture teardown fault isolation, forced output-off before boundary tests) and fixed