### PR TITLE
fix: address 4 code-review findings (setpoint rounding, close() masking, fixture safety, hardware marker)

### DIFF
--- a/src/hm310t/client.py
+++ b/src/hm310t/client.py
@@ -140,6 +140,12 @@ class PowerSupply:
         if not low <= value <= high:
             raise OutOfRangeError(f"{name} must be between {low} and {high}, got {value}")
         raw = register.to_raw(value)
+        # A limit with more precision than the register holds (e.g. voltage_limit=5.009
+        # against a 2dp register) can let `value` pass the check above yet still round to
+        # a raw word past the limit (501 -> 5.01 V). Re-check the value the device will
+        # actually see post-rounding, not just the caller's unrounded float.
+        if not low <= register.from_raw(raw) <= high:
+            raise OutOfRangeError(f"{name} must be between {low} and {high}, got {value}")
         if register.words == 1:
             self._transport.write_register(register.address, raw)
         else:

--- a/src/hm310t/client.py
+++ b/src/hm310t/client.py
@@ -85,7 +85,10 @@ class PowerSupply:
         except BaseException:
             # Spec bug #1: never leak the serial handle if connect or post-connect
             # verification fails partway (close() is safe on a never-opened port).
-            self._transport.close()
+            try:
+                self._transport.close()
+            except Exception:
+                pass  # comms are already broken; don't mask the real init failure
             raise
 
     def _check_decimal_capacity(self) -> None:
@@ -273,4 +276,9 @@ class PowerSupply:
                 except Exception:
                     pass  # comms may be down; don't shadow the exception being raised
         finally:
-            self.close()
+            try:
+                self.close()
+            except Exception:
+                if exc_type is None:
+                    raise  # clean exit: nothing to protect, surface the close failure
+                # else: an exception is already unwinding -- don't replace it

--- a/src/hm310t/transport.py
+++ b/src/hm310t/transport.py
@@ -36,7 +36,9 @@ class Transport:
         try:
             self._client.close()
         except Exception as exc:
-            raise PowerSupplyCommunicationError(f"Failed to close serial connection: {exc}") from exc
+            raise PowerSupplyCommunicationError(
+                f"Failed to close serial connection: {exc}"
+            ) from exc
 
     def read_registers(self, address: int, count: int) -> list[int]:
         try:

--- a/src/hm310t/transport.py
+++ b/src/hm310t/transport.py
@@ -33,7 +33,10 @@ class Transport:
             )
 
     def close(self) -> None:
-        self._client.close()
+        try:
+            self._client.close()
+        except Exception as exc:
+            raise PowerSupplyCommunicationError(f"Failed to close serial connection: {exc}") from exc
 
     def read_registers(self, address: int, count: int) -> list[int]:
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from contextlib import contextmanager
 
 import pytest
 
-from hm310t import PowerSupply
+from hm310t import PowerSupply, PowerSupplyCommunicationError
 
 PSU_PORT = os.environ.get("PSU_TEST_PORT", "/dev/ttyUSB0")
 
@@ -105,8 +105,10 @@ def power_supply() -> Iterator[PowerSupply]:
     """A real HM310T with output forced off for the test and state restored after."""
     try:
         psu = PowerSupply(port=PSU_PORT)
-    except Exception as exc:  # noqa: BLE001
+    except PowerSupplyCommunicationError as exc:
         pytest.skip(f"no HM310T reachable on {PSU_PORT}: {exc}")
+    # IncompatibleDeviceError (wrong model/firmware) and any other unexpected
+    # constructor failure must fail the test loudly, not be swallowed as "no device".
 
     with managed_power_supply(psu) as supply:
         yield supply

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -302,6 +302,23 @@ def test_constructor_rejects_limits_above_device_rating(fake_transports):
         PowerSupply(port="fake", current_limit=20.0)
 
 
+def test_voltage_setter_rejects_value_that_rounds_above_fractional_limit(fake_transports):
+    # voltage_limit=5.009 has more precision than the register's 2dp resolution.
+    # A request at exactly that limit must not round UP to raw 501 (5.01 V) and write it.
+    psu = PowerSupply(port="fake", voltage_limit=5.009)
+    with pytest.raises(OutOfRangeError):
+        psu.voltage = 5.009
+    assert fake_transports[0].write_log == []
+
+
+def test_current_setter_rejects_value_that_rounds_above_fractional_limit(fake_transports):
+    # current_limit=1.2349 has more precision than the register's 3dp resolution.
+    psu = PowerSupply(port="fake", current_limit=1.2349)
+    with pytest.raises(OutOfRangeError):
+        psu.current = 1.2349
+    assert fake_transports[0].write_log == []
+
+
 def test_setter_write_failure_propagates(psu, fake_transports):
     # Bug #8 at the client layer: a transport write failure must raise, never be swallowed.
     fake_transports[0].fail_writes = True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -189,6 +189,44 @@ def test_context_manager_closes_transport(fake_transports):
     assert fake_transports[0].closed
 
 
+class RaisingCloseTransport(FakeTransport):
+    """A Transport whose close() itself fails (e.g. serial handle already gone)."""
+
+    def close(self):
+        raise PowerSupplyCommunicationError("simulated close failure")
+
+
+def test_init_close_failure_does_not_mask_original_error(monkeypatch):
+    # P2: if close() raises while unwinding from a verification failure, the
+    # ORIGINAL error (wrong spec) must still be what's raised, not the close failure.
+    class WrongSpecRaisingClose(RaisingCloseTransport):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.registers[0x0003] = 3005
+
+    monkeypatch.setattr(hm310t.client, "Transport", WrongSpecRaisingClose)
+    with pytest.raises(IncompatibleDeviceError):
+        PowerSupply(port="fake")
+
+
+def test_exit_close_failure_does_not_mask_original_error(monkeypatch):
+    # An exception unwinding out of the `with` block must survive even if the
+    # __exit__ close() call itself raises.
+    monkeypatch.setattr(hm310t.client, "Transport", RaisingCloseTransport)
+    with pytest.raises(RuntimeError):
+        with PowerSupply(port="fake"):
+            raise RuntimeError("boom")
+
+
+def test_exit_close_failure_propagates_on_clean_exit(monkeypatch):
+    # No original exception to protect here, so a close failure on a clean exit
+    # must still surface -- it must not be silently swallowed.
+    monkeypatch.setattr(hm310t.client, "Transport", RaisingCloseTransport)
+    with pytest.raises(PowerSupplyCommunicationError):
+        with PowerSupply(port="fake"):
+            pass
+
+
 def test_voltage_setpoint_write_rounds_not_truncates(psu, fake_transports):
     # Spec bug #7: 0.29 * 100 == 28.999999999999996; int() writes 28, round() writes 29.
     psu.voltage = 0.29

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -311,6 +311,11 @@ def test_comm_address_setter_retargets_transport(psu, fake_transports):
     assert fake_transports[0].slave == 5
 
 
+def test_comm_address_read(psu, fake_transports):
+    fake_transports[0].registers[0x9999] = 7
+    assert psu.comm_address == 7
+
+
 def test_read_raw_register_escape_hatch(psu, fake_transports):
     fake_transports[0].registers[0x0004] = 1234
     assert psu.read_raw_register(0x0004) == 1234
@@ -407,3 +412,27 @@ def test_exit_leaves_output_untouched_on_clean_exit(fake_transports):
     output_writes = [value for addr, value in transport.write_log if addr == 0x0001]
     assert output_writes == [[1]]  # only the deliberate enable; teardown added nothing
     assert transport.closed
+
+
+def test_exit_output_off_failure_does_not_mask_original_error(monkeypatch):
+    # __exit__'s fail-safe output-off attempt is itself allowed to fail (comms may
+    # already be down): the original exception unwinding out of the `with` block
+    # must survive, and close() must still run.
+    class OutputOffFails(FakeTransport):
+        def write_register(self, address, value):
+            if address == 0x0001 and value == 0:
+                raise PowerSupplyCommunicationError("simulated output-off failure")
+            return super().write_register(address, value)
+
+    created = []
+
+    def factory(*args, **kwargs):
+        transport = OutputOffFails(*args, **kwargs)
+        created.append(transport)
+        return transport
+
+    monkeypatch.setattr(hm310t.client, "Transport", factory)
+    with pytest.raises(RuntimeError):
+        with PowerSupply(port="fake"):
+            raise RuntimeError("boom")
+    assert created[0].closed

--- a/tests/test_conftest_safety.py
+++ b/tests/test_conftest_safety.py
@@ -8,12 +8,18 @@ the in-memory FakeTransport instead of a real device.
 
 from __future__ import annotations
 
+import pathlib
+
 import pytest
 from conftest import managed_power_supply
 from test_client import FakeTransport
 
 import hm310t.client
 from hm310t import PowerSupply, PowerSupplyCommunicationError
+
+pytest_plugins = ["pytester"]
+
+_CONFTEST_SOURCE = pathlib.Path(__file__).parent.joinpath("conftest.py").read_text()
 
 OUTPUT = 0x0001
 SET_VOLTAGE = 0x0030
@@ -94,3 +100,43 @@ def test_managed_supply_skips_setpoint_restore_when_teardown_force_off_fails(mon
     assert (OUTPUT, [1]) not in transport.write_log  # output was never re-enabled
     assert transport.registers[OUTPUT] == 0  # device left physically off
     assert transport.closed
+
+
+def _assert_power_supply_fixture_outcome(pytester, exc_name, **expected_outcomes):
+    """Run the real ``power_supply`` fixture in an isolated pytest process against a
+    PowerSupply() constructor that always raises ``exc_name``, and assert the
+    resulting pass/skip/error outcome."""
+    pytester.makeconftest(_CONFTEST_SOURCE)
+    pytester.makepyfile(f"""
+        import pytest
+        from hm310t import {exc_name}
+
+        @pytest.fixture(autouse=True)
+        def _make_powersupply_raise(monkeypatch):
+            import conftest
+
+            def _raise(*args, **kwargs):
+                raise {exc_name}("simulated")
+
+            monkeypatch.setattr(conftest, "PowerSupply", _raise)
+
+        def test_dummy(power_supply):
+            pass
+        """)
+    result = pytester.runpytest_subprocess()
+    result.assert_outcomes(**expected_outcomes)
+
+
+def test_power_supply_fixture_skips_on_communication_error(pytester):
+    # The ordinary "nothing plugged in" case must still skip cleanly.
+    _assert_power_supply_fixture_outcome(
+        pytester, "PowerSupplyCommunicationError", skipped=1
+    )
+
+
+def test_power_supply_fixture_fails_loudly_on_incompatible_device(pytester):
+    # A wrong-model/firmware device (or any other constructor bug) must fail the
+    # test, not be swallowed as "no device reachable."
+    _assert_power_supply_fixture_outcome(
+        pytester, "IncompatibleDeviceError", errors=1
+    )

--- a/tests/test_conftest_safety.py
+++ b/tests/test_conftest_safety.py
@@ -129,14 +129,10 @@ def _assert_power_supply_fixture_outcome(pytester, exc_name, **expected_outcomes
 
 def test_power_supply_fixture_skips_on_communication_error(pytester):
     # The ordinary "nothing plugged in" case must still skip cleanly.
-    _assert_power_supply_fixture_outcome(
-        pytester, "PowerSupplyCommunicationError", skipped=1
-    )
+    _assert_power_supply_fixture_outcome(pytester, "PowerSupplyCommunicationError", skipped=1)
 
 
 def test_power_supply_fixture_fails_loudly_on_incompatible_device(pytester):
     # A wrong-model/firmware device (or any other constructor bug) must fail the
     # test, not be swallowed as "no device reachable."
-    _assert_power_supply_fixture_outcome(
-        pytester, "IncompatibleDeviceError", errors=1
-    )
+    _assert_power_supply_fixture_outcome(pytester, "IncompatibleDeviceError", errors=1)

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -127,6 +127,7 @@ def test_invalid_port_raises_communication_error():
         PowerSupply(port="/dev/hm310t-nonexistent")
 
 
+@hardware
 @pytest.mark.requires_load
 @pytest.mark.skipif(not LOAD_ATTACHED, reason="set PSU_LOAD_ATTACHED=1 with a load wired up")
 def test_measurement_under_load(power_supply):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -26,6 +26,10 @@ def test_connect_failure_raises(mock_client):
         Transport("/dev/ttyUSB0").connect()
 
 
+def test_connect_success_returns_none(mock_client):
+    assert Transport("/dev/ttyUSB0").connect() is None
+
+
 def test_connect_exception_raises_typed_error(mock_client):
     # pymodbus 3.2.2 returns False on a bad port, but "every transport failure
     # raises the typed error" must hold even if a pymodbus version raises here
@@ -84,10 +88,29 @@ def test_non_modbus_exception_raises_typed_error(mock_client):
         Transport("/dev/ttyUSB0").read_register(0x0030)
 
 
+def test_write_register_error_response_raises(mock_client):
+    mock_client.write_register.return_value.isError.return_value = True
+    with pytest.raises(PowerSupplyCommunicationError):
+        Transport("/dev/ttyUSB0").write_register(0x0030, 500)
+
+
 def test_write_error_response_raises(mock_client):
     mock_client.write_registers.return_value.isError.return_value = True
     with pytest.raises(PowerSupplyCommunicationError):
         Transport("/dev/ttyUSB0").write_registers(0x0022, [0, 20000])
+
+
+def test_write_registers_exception_raises_typed_error(mock_client):
+    mock_client.write_registers.side_effect = OSError("device unplugged")
+    with pytest.raises(PowerSupplyCommunicationError):
+        Transport("/dev/ttyUSB0").write_registers(0x0022, [0, 20000])
+
+
+def test_write_registers_success_returns_none(mock_client):
+    response = MagicMock()
+    response.isError.return_value = False
+    mock_client.write_registers.return_value = response
+    assert Transport("/dev/ttyUSB0").write_registers(0x0022, [0, 20000]) is None
 
 
 def test_writes_use_configured_slave(mock_client):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -99,6 +99,14 @@ def test_writes_use_configured_slave(mock_client):
     mock_client.write_register.assert_called_with(0x0030, 500, slave=3)
 
 
+def test_close_exception_raises_typed_error(mock_client):
+    # close() was the one I/O method that didn't wrap failures (bug #2) -- a raw
+    # OSError from the serial handle must surface as our own typed error too.
+    mock_client.close.side_effect = OSError("device unplugged")
+    with pytest.raises(PowerSupplyCommunicationError):
+        Transport("/dev/ttyUSB0").close()
+
+
 def test_no_dead_method_kwarg(monkeypatch):
     # Spec bug #6: method='rtu' is not a real ModbusSerialClient parameter in pymodbus 3.2.2.
     ctor = MagicMock(return_value=MagicMock())


### PR DESCRIPTION
## Summary

Four issues found in an independent code review of `src/hm310t`, verified against the codebase and each fixed with a dedicated test, one commit per issue:

- **P1** — `_write_scaled` compared the caller's raw float against `voltage_limit`/`current_limit` before rounding to the register's fixed-point resolution. A limit with more precision than the register holds (e.g. `voltage_limit=5.009` on a 2dp register) could let a request at that exact value round *up* past the limit (raw 501 → 5.01 V). Now re-checks the post-rounding value before writing.
- **P2** — `Transport.close()` was the one I/O method that didn't wrap failures in `PowerSupplyCommunicationError`, and a close() failure during exception unwinding (in `__init__`'s cleanup path or `__exit__`'s `finally`) could replace the real error being propagated. Wrapped consistently; unwinding now suppresses close failures so the original exception stays primary (a clean-exit close failure still surfaces).
- **P3** — the hardware contract suite's `power_supply` fixture caught bare `Exception` around `PowerSupply()` construction, so an `IncompatibleDeviceError` (wrong model/firmware) or any unexpected bug was silently reported as "no device reachable" instead of failing the test. Now skips only on `PowerSupplyCommunicationError`.
- **P4** — `test_measurement_under_load` was missing the `@hardware` marker despite using the real-hardware fixture, so `pytest -m hardware` silently missed it.

Also closes two pre-existing coverage gaps found while measuring coverage on this branch (unrelated to the review, caught along the way): `comm_address`'s read path, and `__exit__`'s output-off-failure branch.

## Test plan
- [x] 62/62 hardware-free tests pass (`pytest -m "not hardware and not requires_load"`)
- [x] 100% line/branch coverage on `src/hm310t`
- [x] ruff check + ruff format --check clean
- [x] mypy clean
- [x] Fresh-context code-reviewer pass on the full diff (found only two cosmetic lint nits, fixed in the last commit)
- [x] Each fix was written test-first (confirmed red before the fix, green after)